### PR TITLE
feat(inline): Inline calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,33 @@ class MyContainer {
 ```
 Here is the list of APIs:  
 
-| Name                 | Signature       | description            |
+| Name                 | Signature       | Description            |
 |----------------------|:---------------:|------------------------|
 | open                 | `() => void`    | Opens the date picker  |
 | close                | `() => void`    | Closes the date picker |
+
+
+## Inline
+
+You can use the `<dp-calendar>` component to display the calendar widget without an associated input box.
+
+i.e.
+```html
+<dp-calendar [(selected)]="dates" [config]="calendarConfig"></dp-calendar>
+```
+
+### Inputs
+
+| Name                 | Type              | Description            |
+|----------------------|:-----------------:|------------------------|
+| selected             | `Moment[]`        | Opens the date picker  |
+| config               | `ICalendarConfig` | A subset of the `IDayPickerConfig`.<br>Properties include: `firstDayOfWeek`, `calendarsAmount`, `min`, `max`, `allowMultiSelect`, `format`, `monthFormat`, and `monthFormatter`.<br>These properties behave as described in the `Configuration` section above. |
+
+### Outputs
+
+| Name                 | Type                      | Description                                                        |
+|----------------------|:-------------------------:|--------------------------------------------------------------------|
+| selectedChange       | `EventEmitter<Moment[]>`  | Emits the currently selected days every time the selection changes |
+| dayClick             | `EventEmitter<IDayEvent>` | Emits every time a day is clicked on the calendar                  |
+| dayContextmenu       | `EventEmitter<IDayEvent>` | Emits every time a day is right-clicked on the calendar            |
+| calendarMove         | `EventEmitter<Moment>`    | Emits every time the calendar moves to a different set of months. The date emitted is the first month displayed. |

--- a/src/app/demo/demo/demo.component.html
+++ b/src/app/demo/demo/demo.component.html
@@ -11,9 +11,10 @@
     </p>
   </div>
 
-  <div>
+  <div class="dp-demo-container">
     <div class="dp-picker-container">
       <form #form="ngForm">
+        <label>Date picker (<code>&lt;dp-day-picker&gt;</code>)</label><br>
         <dp-day-picker name="dateItem"
                        #dateItem="ngModel"
                        #dayPicker
@@ -32,6 +33,16 @@
         <div *ngIf="dateItem.errors && dateItem.errors.minDate">minDate invalid</div>
         <div *ngIf="dateItem.errors && dateItem.errors.maxDate">maxDate invalid</div>
       </form>
+    </div>
+
+    <div class="dp-inline">
+      <label>Inline Calendar (<code>&lt;dp-calendar&gt;</code>)</label><br>
+      <dp-calendar
+        [class.dp-material]="material"
+        [(selected)]="dates"
+        (selectedChange)="log($event)"
+        [config]="config">
+      </dp-calendar>
     </div>
   </div>
 
@@ -305,6 +316,9 @@
     {{example | json}}
   </div>
 </div>
-<p>
-  <a routerLink="multiselect-test">Multiselect Test Page</a>
-</p>
+
+<ul>
+  <li>
+    <a routerLink="multiselect-test">Multiselect Test</a>
+  </li>
+</ul>

--- a/src/app/demo/demo/demo.component.less
+++ b/src/app/demo/demo/demo.component.less
@@ -8,9 +8,17 @@
     text-decoration: underline;
   }
 
+  .dp-demo-container {
+    text-align: center;
+  }
+
   .dp-picker-container {
     margin: 20px auto;
     width: 212px;
+  }
+
+  .dp-inline {
+    display: inline-block;
   }
 
   .dp-attributes, .dp-configs, .dp-api {

--- a/src/app/demo/demo/demo.component.spec.ts
+++ b/src/app/demo/demo/demo.component.spec.ts
@@ -1,7 +1,7 @@
 /* tslint:disable:no-unused-variable */
 
-import { TestBed, async } from '@angular/core/testing';
-import { DemoComponent } from './demo.component';
+import {TestBed, async} from '@angular/core/testing';
+import {DemoComponent} from './demo.component';
 
 describe('Component: Demo', () => {
   it('should create an instance', () => {

--- a/src/app/demo/demo/demo.component.ts
+++ b/src/app/demo/demo/demo.component.ts
@@ -15,6 +15,7 @@ export class DemoComponent {
   readonly DAYS = ['su', 'mo', 'tu', 'we', 'th', 'fr', 'sa'];
 
   date: Moment;
+  dates: Moment[] = [];
 
   material: boolean = true;
   required: boolean = false;

--- a/src/app/dp-calendar-month/config/calendar-month-config.model.ts
+++ b/src/app/dp-calendar-month/config/calendar-month-config.model.ts
@@ -1,0 +1,14 @@
+import {Moment} from 'moment';
+import {WeekDays} from '../../common/types/week-days.type';
+
+export interface ICalendarMonthConfig extends IBaseCalendarConfig {
+  month: Moment;
+  firstDayOfWeek: WeekDays;
+  min?: Moment;
+  max?: Moment;
+}
+
+export interface IBaseCalendarConfig {
+  isDisabledCallback?: (date: Moment) => boolean;
+  weekdayNames?: {[key: string]: string};
+}

--- a/src/app/dp-calendar-month/config/day.model.ts
+++ b/src/app/dp-calendar-month/config/day.model.ts
@@ -8,3 +8,8 @@ export interface ICalendarDay {
   nextMonth?: boolean;
   currentDay?: boolean;
 }
+
+export interface IDayEvent {
+  day: ICalendarDay;
+  event: MouseEvent;
+}

--- a/src/app/dp-calendar-month/dp-calendar-month.component.html
+++ b/src/app/dp-calendar-month/dp-calendar-month.component.html
@@ -1,0 +1,20 @@
+<div class="dp-calendar-wrapper">
+  <div class="dp-weekdays">
+    <span class="dp-calendar-weekday" *ngFor="let weekday of weekdays">{{weekday}}</span>
+  </div>
+  <div class="dp-calendar-week" *ngFor="let week of weeks">
+    <button class="dp-calendar-day"
+            *ngFor="let day of week"
+            (click)="dayClick.emit({day: day, event: $event})"
+            [disabled]="isDisabledDay(day)"
+            [ngClass]="{
+              'dp-selected': day.selected,
+              'dp-current-month': day.currentMonth,
+              'dp-prev-month': day.prevMonth,
+              'dp-next-month': day.nextMonth,
+              'dp-current-day': day.currentDay
+            }">
+      {{day.date.format('DD')}}
+    </button>
+  </div>
+</div>

--- a/src/app/dp-calendar-month/dp-calendar-month.component.less
+++ b/src/app/dp-calendar-month/dp-calendar-month.component.less
@@ -1,0 +1,87 @@
+& {
+  @button-size: 30px;
+  @black: #000000;
+  @white: #FFFFFF;
+
+  :host {
+    display: inline-block;
+  }
+
+  .dp-calendar-wrapper {
+    box-sizing: border-box;
+    border: 1px solid @black;
+
+    .dp-calendar-weekday:first-child {
+      border-left: none;
+    }
+  }
+
+  .dp-calendar-weekday {
+    box-sizing: border-box;
+    display: inline-block;
+    width: @button-size;
+    text-align: center;
+    border-left: 1px solid @black;
+    border-bottom: 1px solid @black;
+  }
+
+  .dp-calendar-day {
+    box-sizing: border-box;
+    width: @button-size;
+    height: @button-size;
+    cursor: pointer;
+  }
+
+  .dp-selected {
+    background: blue;
+  }
+
+  .dp-prev-month, .dp-next-month {
+    opacity: 0.5;
+  }
+}
+
+& {
+  @basic-height: 30px;
+
+  :host(.dp-material) {
+    .dp-calendar-weekday {
+      height: @basic-height - 5px;
+      width: @basic-height;
+      line-height: @basic-height - 5px;
+      background: #E0E0E0;
+      border: none;
+    }
+
+    .dp-calendar-wrapper {
+      border: none;
+    }
+
+    .dp-calendar-day {
+      box-sizing: border-box;
+      height: @basic-height;
+      width: @basic-height;
+      background: white;
+      border-radius: 50%;
+      border: none;
+      outline: none;
+
+      &:hover {
+        background: #E0E0E0;
+      }
+    }
+
+    .dp-selected {
+      background: #106CC8;
+      color: white;
+
+      &:hover {
+        background: #106CC8;
+      }
+    }
+
+    .dp-current-day {
+      border: 1px solid #106CC8;
+    }
+  }
+}

--- a/src/app/dp-calendar-month/dp-calendar-month.component.spec.ts
+++ b/src/app/dp-calendar-month/dp-calendar-month.component.spec.ts
@@ -1,0 +1,8 @@
+/* tslint:disable:no-unused-variable */
+
+import {TestBed, async} from '@angular/core/testing';
+import {DpCalendarMonthComponent} from './dp-calendar-month.component';
+
+describe('Component: ObCalendar', () => {
+
+});

--- a/src/app/dp-calendar-month/dp-calendar-month.component.ts
+++ b/src/app/dp-calendar-month/dp-calendar-month.component.ts
@@ -1,0 +1,41 @@
+import {Component, OnInit, Input, Output, EventEmitter, OnChanges, SimpleChanges} from '@angular/core';
+import {CalendarMonthService} from './service/calendar-month.service';
+import {ICalendarMonthConfig} from './config/calendar-month-config.model';
+import {ICalendarDay, IDayEvent} from './config/day.model';
+import {Moment} from 'moment';
+
+@Component({
+  selector: 'dp-calendar-month',
+  templateUrl: './dp-calendar-month.component.html',
+  styleUrls: ['./dp-calendar-month.component.less'],
+  providers: [CalendarMonthService]
+})
+export class DpCalendarMonthComponent implements OnInit, OnChanges {
+  @Input() config: ICalendarMonthConfig;
+  @Input() selected: Moment[];
+  @Output() dayClick: EventEmitter<IDayEvent> = new EventEmitter();
+  @Output() dayContextmenu: EventEmitter<IDayEvent> = new EventEmitter();
+  weeks: ICalendarDay[][];
+  weekdays: string[];
+
+  constructor(private calendarService: CalendarMonthService) {
+  }
+
+  ngOnInit() {
+    this.weeks = this.calendarService.generateMonthArray(this.config.firstDayOfWeek, this.config.month,
+      this.selected);
+    this.weekdays = this.calendarService.generateWeekdays(this.config.firstDayOfWeek, this.config.weekdayNames);
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    const {selected} = changes;
+    if (selected && !selected.isFirstChange()) {
+      this.weeks = this.calendarService.generateMonthArray(this.config.firstDayOfWeek, this.config.month,
+        this.selected);
+    }
+  }
+
+  isDisabledDay(day: ICalendarDay) {
+    return this.calendarService.isDateDisabled(day, this.config);
+  }
+}

--- a/src/app/dp-calendar-month/service/calendar-month.service.spec.ts
+++ b/src/app/dp-calendar-month/service/calendar-month.service.spec.ts
@@ -1,31 +1,31 @@
 /* tslint:disable:no-unused-variable */
 
 import {TestBed, async, inject} from '@angular/core/testing';
-import {CalendarService} from './calendar.service';
+import {CalendarMonthService} from './calendar-month.service';
 import * as moment from 'moment';
-import {ICalendarConfig} from '../config/calendar-config.model';
+import {ICalendarMonthConfig} from '../config/calendar-month-config.model';
 import {Moment} from 'moment';
 
 describe('Service: Calendar', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [CalendarService]
+      providers: [CalendarMonthService]
     });
   });
 
-  it('should check the generateDaysMap method', inject([CalendarService], (service: CalendarService) => {
+  it('should check the generateDaysMap method', inject([CalendarMonthService], (service: CalendarMonthService) => {
     expect(service.generateDaysIndexMap('su')).toEqual({0: 'su', 1: 'mo', 2: 'tu', 3: 'we', 4: 'th', 5: 'fr', 6: 'sa'});
     expect(service.generateDaysIndexMap('mo')).toEqual({0: 'mo', 1: 'tu', 2: 'we', 3: 'th', 4: 'fr', 5: 'sa', 6: 'su'});
     expect(service.generateDaysIndexMap('we')).toEqual({0: 'we', 1: 'th', 2: 'fr', 3: 'sa', 4: 'su', 5: 'mo', 6: 'tu'});
   }));
 
-  it('should check the generateDaysMap method', inject([CalendarService], (service: CalendarService) => {
+  it('should check the generateDaysMap method', inject([CalendarMonthService], (service: CalendarMonthService) => {
     expect(service.generateDaysMap('su')).toEqual({'su': 0, 'mo': 1, 'tu': 2, 'we': 3, 'th': 4, 'fr': 5, 'sa': 6});
     expect(service.generateDaysMap('mo')).toEqual({'mo': 0, 'tu': 1, 'we': 2, 'th': 3, 'fr': 4, 'sa': 5, 'su': 6});
     expect(service.generateDaysMap('we')).toEqual({'we': 0, 'th': 1, 'fr': 2, 'sa': 3, 'su': 4, 'mo': 5, 'tu': 6});
   }));
 
-  it('should check the generateMonthArray method', inject([CalendarService], (service: CalendarService) => {
+  it('should check the generateMonthArray method', inject([CalendarMonthService], (service: CalendarMonthService) => {
     let monthWeeks = service.generateMonthArray('su', moment('11-10-2016', 'DD-MM-YYYY'), [moment('11-10-2016', 'DD-MM-YYYY')]);
     expect(monthWeeks[0][0].date.format('DD-MM-YYYY')).toBe('25-09-2016');
     expect(monthWeeks[0][0].prevMonth).toBe(true);
@@ -67,7 +67,7 @@ describe('Service: Calendar', () => {
   }));
 
 
-  it('should check the generateWeekdays method', inject([CalendarService], (service: CalendarService) => {
+  it('should check the generateWeekdays method', inject([CalendarMonthService], (service: CalendarMonthService) => {
     expect(service.generateWeekdays('su', {
       su: 'sun',
       mo: 'mon',
@@ -99,10 +99,9 @@ describe('Service: Calendar', () => {
     })).toEqual(['2', '3', '4', '5', '6', '7', '1']);
   }));
 
-  it('should check isDateDisabled method', inject([CalendarService], (service: CalendarService) => {
-    const config: ICalendarConfig = {
+  it('should check isDateDisabled method', inject([CalendarMonthService], (service: CalendarMonthService) => {
+    const config: ICalendarMonthConfig = {
       month: moment('13-10-2016', 'DD-MM-YYYY'),
-      selected: [moment('13-10-2016', 'DD-MM-YYYY')],
       firstDayOfWeek: 'su',
       min: moment('13-10-2016', 'DD-MM-YYYY').subtract(1, 'day'),
       max: moment('13-10-2016', 'DD-MM-YYYY').add(1, 'day')

--- a/src/app/dp-calendar-month/service/calendar-month.service.ts
+++ b/src/app/dp-calendar-month/service/calendar-month.service.ts
@@ -4,10 +4,10 @@ import * as moment from 'moment';
 import {WeekDays} from '../../common/types/week-days.type';
 import {UtilsService} from '../../common/services/utils/utils.service';
 import {ICalendarDay} from '../config/day.model';
-import {ICalendarConfig} from '../config/calendar-config.model';
+import {ICalendarMonthConfig} from '../config/calendar-month-config.model';
 
 @Injectable()
-export class CalendarService {
+export class CalendarMonthService {
   readonly DAYS = ['su', 'mo', 'tu', 'we', 'th', 'fr', 'sa'];
 
   generateDaysIndexMap(firstDayOfWeek: WeekDays) {
@@ -78,7 +78,7 @@ export class CalendarService {
     return weekdays;
   }
 
-  isDateDisabled(day: ICalendarDay, config: ICalendarConfig): boolean {
+  isDateDisabled(day: ICalendarDay, config: ICalendarMonthConfig): boolean {
     if (config.isDisabledCallback) {
       return config.isDisabledCallback(day.date);
     }

--- a/src/app/dp-calendar/config/calendar-config.model.ts
+++ b/src/app/dp-calendar/config/calendar-config.model.ts
@@ -1,12 +1,14 @@
+import {IBaseCalendarConfig} from './../../dp-calendar-month/config/calendar-month-config.model';
 import {Moment} from 'moment';
 import {WeekDays} from '../../common/types/week-days.type';
 
-export interface ICalendarConfig {
-  month: Moment;
-  selected: Moment[];
-  firstDayOfWeek: WeekDays;
-  min?: Moment;
-  max?: Moment;
-  isDisabledCallback?: (date: Moment) => boolean;
-  weekdayNames?: {[key: string]: string};
+export interface ICalendarConfig extends IBaseCalendarConfig {
+  firstDayOfWeek?: WeekDays;
+  calendarsAmount?: number;
+  min?: Moment | string;
+  max?: Moment | string;
+  allowMultiSelect?: boolean;
+  format?: string;
+  monthFormat?: string;
+  monthFormatter?: (date: Moment) => string;
 }

--- a/src/app/dp-calendar/config/calendar.service.spec.ts
+++ b/src/app/dp-calendar/config/calendar.service.spec.ts
@@ -1,0 +1,101 @@
+/* tslint:disable:no-unused-variable */
+
+import {TestBed, async, inject} from '@angular/core/testing';
+import {CalendarService} from './calendar.service';
+import * as moment from 'moment';
+import {Moment} from 'moment';
+
+describe('Service: DayPicker', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [CalendarService]
+    });
+  });
+
+  it('should check generateCalendars method', inject([CalendarService], (service: CalendarService) => {
+    const calendars1 = service.generateCalendars({calendarsAmount: 1}, null);
+    expect(calendars1.length).toBe(1);
+    expect(calendars1[0].month.isSame(moment(), 'month')).toBe(true);
+
+    const calendars2 = service.generateCalendars({calendarsAmount: 2}, null);
+    expect(calendars2.length).toBe(2);
+    expect(calendars2[0].month.isSame(moment(), 'month')).toBe(true);
+    expect(calendars2[1].month.isSame(moment().add(1, 'month'), 'month')).toBe(true);
+
+    const calendars2_1 = service.generateCalendars({calendarsAmount: 2}, []);
+    expect(calendars2_1.length).toBe(2);
+    expect(calendars2_1[0].month.isSame(moment(), 'month')).toBe(true);
+    expect(calendars2_1[1].month.isSame(moment().add(1, 'month'), 'month')).toBe(true);
+
+    const calendars3 = service.generateCalendars({calendarsAmount: 2}, [moment('13-10-2015', 'DD-MM-YYYY')]);
+    expect(calendars3.length).toBe(2);
+    expect(calendars3[0].month.isSame(moment('13-10-2015', 'DD-MM-YYYY'), 'month')).toBe(true);
+    expect(calendars3[1].month.isSame(moment('13-11-2015', 'DD-MM-YYYY'), 'month')).toBe(true);
+
+    const calendars3_1 = service.generateCalendars(
+      {calendarsAmount: 2},
+      [moment('13-10-2015', 'DD-MM-YYYY'), moment('13-11-2015', 'DD-MM-YYYY')]
+    );
+    expect(calendars3_1.length).toBe(2);
+    expect(calendars3_1[0].month.isSame(moment('13-10-2015', 'DD-MM-YYYY'), 'month')).toBe(true);
+    expect(calendars3_1[1].month.isSame(moment('13-11-2015', 'DD-MM-YYYY'), 'month')).toBe(true);
+
+    const calendars4 = service.generateCalendars({calendarsAmount: 2}, [moment()], moment('13-10-2015', 'DD-MM-YYYY'));
+    expect(calendars4.length).toBe(2);
+    expect(calendars4[0].month.isSame(moment('13-10-2015', 'DD-MM-YYYY'), 'month')).toBe(true);
+    expect(calendars4[1].month.isSame(moment('13-11-2015', 'DD-MM-YYYY'), 'month')).toBe(true);
+  }));
+
+  it('should check isDateValid method', inject([CalendarService], (service: CalendarService) => {
+    expect(service.isDateValid('13-10-2015', 'DD-MM-YYYY')).toBe(true);
+    expect(service.isDateValid('13-10-2015', 'DD-MM-YY')).toBe(false);
+    expect(service.isDateValid('', 'DD-MM-YY')).toBe(true);
+  }));
+
+  it('should check moveCalendars method', inject([CalendarService], (service: CalendarService) => {
+    const calendars1 = service.moveCalendars({calendarsAmount: 1}, null, moment(), 1);
+    expect(calendars1.length).toBe(1);
+    expect(calendars1[0].month.isSame(moment().add(1, 'month'), 'month')).toBe(true);
+
+    const calendars2 = service.moveCalendars({calendarsAmount: 2}, null, moment(), 1);
+    expect(calendars2.length).toBe(2);
+    expect(calendars2[0].month.isSame(moment().add(1, 'month'), 'month')).toBe(true);
+    expect(calendars2[1].month.isSame(moment().add(2, 'month'), 'month')).toBe(true);
+
+    const calendars3 = service.moveCalendars({calendarsAmount: 2}, null, moment(), -1);
+    expect(calendars3.length).toBe(2);
+    expect(calendars3[0].month.isSame(moment().add(-1, 'month'), 'month')).toBe(true);
+    expect(calendars3[1].month.isSame(moment(), 'month')).toBe(true);
+  }));
+
+  it('should check isMinMonth method', inject([CalendarService], (service: CalendarService) => {
+    expect(service.isMinMonth(moment(), moment())).toBe(true);
+    expect(service.isMinMonth(moment().subtract(1, 'month'), moment())).toBe(false);
+    expect(service.isMinMonth(null, moment())).toBe(false);
+  }));
+
+  it('should check isMaxMonth method', inject([CalendarService], (service: CalendarService) => {
+    expect(service.isMaxMonth(moment(), moment())).toBe(true);
+    expect(service.isMaxMonth(moment().add(1, 'month'), moment())).toBe(false);
+    expect(service.isMinMonth(null, moment())).toBe(false);
+  }));
+
+  it('should check getConfig method for dates format aspect', inject([CalendarService], (service: CalendarService) => {
+    const config1 = service.getConfig({
+      min: '2016-10-25',
+      max: '2017-10-25',
+      format: 'YYYY-MM-DD'
+    });
+
+    expect((<Moment>config1.min).isSame(moment('2016-10-25', 'YYYY-MM-DD'), 'day')).toBe(true);
+    expect((<Moment>config1.max).isSame(moment('2017-10-25', 'YYYY-MM-DD'), 'day')).toBe(true);
+
+    const config2 = service.getConfig({
+      min: moment('2016-10-25', 'YYYY-MM-DD'),
+      max: moment('2017-10-25', 'YYYY-MM-DD')
+    });
+
+    expect((<Moment>config2.min).isSame(moment('2016-10-25', 'YYYY-MM-DD'), 'day')).toBe(true);
+    expect((<Moment>config2.max).isSame(moment('2017-10-25', 'YYYY-MM-DD'), 'day')).toBe(true);
+  }));
+});

--- a/src/app/dp-calendar/config/calendar.service.ts
+++ b/src/app/dp-calendar/config/calendar.service.ts
@@ -1,0 +1,74 @@
+import {UtilsService} from '../../common/services/utils/utils.service';
+import {ICalendarMonthConfig} from '../../dp-calendar-month/config/calendar-month-config.model';
+import {ICalendarConfig} from './calendar-config.model';
+import {Injectable} from '@angular/core';
+import * as moment from 'moment';
+import {Moment} from 'moment';
+
+@Injectable()
+export class CalendarService {
+  private defaultConfig: ICalendarConfig = {
+    firstDayOfWeek: 'su',
+    calendarsAmount: 1,
+    monthFormat: 'MMM, YYYY',
+    weekdayNames: {
+      su: 'sun',
+      mo: 'mon',
+      tu: 'tue',
+      we: 'wed',
+      th: 'thu',
+      fr: 'fri',
+      sa: 'sat'
+    },
+  };
+
+  private formatValues(config: ICalendarConfig): void {
+    const {format, min, max} = config;
+
+    if (min && typeof min === 'string') {
+      config.min = moment(min, format);
+    }
+
+    if (max && typeof max === 'string') {
+      config.max = moment(max, format);
+    }
+  }
+
+  getConfig(config: ICalendarConfig) {
+    const _config = Object.assign({}, this.defaultConfig, config);
+    this.formatValues(_config);
+    return _config;
+  }
+
+  generateCalendars(config: ICalendarConfig, selected: Moment[], month?: Moment): ICalendarMonthConfig[] {
+    const base = (month && month.clone()) || (selected && selected[0] && selected[0].clone()) || moment();
+    return UtilsService.createArray(config.calendarsAmount).map((n: number, i: number) => ({
+      month: base.clone().add(i, 'month'),
+      selected: selected,
+      firstDayOfWeek: config.firstDayOfWeek,
+      weekdayNames: config.weekdayNames,
+      min: <Moment>config.min,
+      max: <Moment>config.max
+    }));
+  }
+
+  isDateValid(date: string, format: string): boolean {
+    if (date === '') {
+      return true;
+    }
+    return moment(date, format, true).isValid();
+  }
+
+  moveCalendars(config: ICalendarConfig, selected: Moment[], base: Moment, months: number): ICalendarMonthConfig[] {
+    const month = base.clone().add(months, 'month');
+    return this.generateCalendars(config, selected, month);
+  }
+
+  isMinMonth(min: Moment, month): boolean {
+    return min ? month.clone().subtract(1, 'month').isBefore(min, 'month') : false;
+  }
+
+  isMaxMonth(max: Moment, month): boolean {
+    return max ? month.clone().add(1, 'month').isAfter(max, 'month') : false;
+  }
+}

--- a/src/app/dp-calendar/dp-calendar.component.html
+++ b/src/app/dp-calendar/dp-calendar.component.html
@@ -1,20 +1,22 @@
-<div class="dp-calendar-wrapper">
-  <div class="dp-weekdays">
-    <span class="dp-calendar-weekday" *ngFor="let weekday of weekdays">{{weekday}}</span>
-  </div>
-  <div class="dp-calendar-week" *ngFor="let week of weeks">
-    <button class="dp-calendar-day"
-            *ngFor="let day of week"
-            (click)="dateClick(day)"
-            [disabled]="isDisabledDay(day)"
-            [ngClass]="{
-              'dp-selected': day.selected,
-              'dp-current-month': day.currentMonth,
-              'dp-prev-month': day.prevMonth,
-              'dp-next-month': day.nextMonth,
-              'dp-current-day': day.currentDay
-            }">
-      {{day.date.format('DD')}}
+<div class="dp-calendar-container"
+     *ngFor="let calendar of calendars; let start = first; let end = last">
+  <div class="dp-calendar-nav-container">
+    <button class="dp-calendar-nav-left"
+            *ngIf="start"
+            [disabled]="isLeftNavDisabled(calendar.month)"
+            (click)="moveCalendars(calendars[0].month, -1)"> <
+    </button>
+    <span class="dp-calendar-month">{{getMonthToDisplay(calendar.month)}}</span>
+    <button class="dp-calendar-nav-right"
+            *ngIf="end"
+            [disabled]="isRightNavDisabled(calendar.month)"
+            (click)="moveCalendars(calendars[0].month, 1)"> >
     </button>
   </div>
+  <dp-calendar-month
+    [selected]="selected"
+    [config]="calendar"
+    (dayContextmenu)="dayContextmenu.emit($event)"
+    (dayClick)="daySelected($event)">
+  </dp-calendar-month>
 </div>

--- a/src/app/dp-calendar/dp-calendar.component.less
+++ b/src/app/dp-calendar/dp-calendar.component.less
@@ -1,87 +1,115 @@
 & {
-  @button-size: 30px;
   @black: #000000;
   @white: #FFFFFF;
 
-  :host {
+  .dp-calendar-container {
     display: inline-block;
   }
 
-  .dp-calendar-wrapper {
+  .dp-calendar-nav-container {
+    position: relative;
     box-sizing: border-box;
+    height: 25px;
     border: 1px solid @black;
-
-    .dp-calendar-weekday:first-child {
-      border-left: none;
-    }
+    border-bottom: none;
   }
 
-  .dp-calendar-weekday {
-    box-sizing: border-box;
-    display: inline-block;
-    width: @button-size;
-    text-align: center;
-    border-left: 1px solid @black;
-    border-bottom: 1px solid @black;
-  }
-
-  .dp-calendar-day {
-    box-sizing: border-box;
-    width: @button-size;
-    height: @button-size;
+  .dp-calendar-nav-left, .dp-calendar-nav-right {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
     cursor: pointer;
   }
 
-  .dp-selected {
-    background: blue;
+  .dp-calendar-nav-left {
+    left: 0;
   }
 
-  .dp-prev-month, .dp-next-month {
-    opacity: 0.5;
+  .dp-calendar-nav-right {
+    right: 0;
+  }
+
+  .dp-calendar-month {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
   }
 }
 
 & {
+  @deep: ~">>>";
   @basic-height: 30px;
 
   :host(.dp-material) {
-    .dp-calendar-weekday {
-      height: @basic-height - 5px;
-      width: @basic-height;
-      line-height: @basic-height - 5px;
-      background: #E0E0E0;
+
+    .dp-calendar-container {
+      background: white;
+
+      &:not(:first-of-type) {
+        border-left: 1px solid #B0AFAF;
+      }
+    }
+
+    .dp-calendar-nav-container {
+      height: @basic-height;
       border: none;
     }
 
-    .dp-calendar-wrapper {
+    .dp-calendar-nav-left, .dp-calendar-nav-right {
       border: none;
+      background: white;
+      outline: none;
+      font-size: 16px;
     }
 
-    .dp-calendar-day {
+    .dp-daypicker-input {
       box-sizing: border-box;
       height: @basic-height;
-      width: @basic-height;
-      background: white;
-      border-radius: 50%;
-      border: none;
+      width: (@basic-height * 7) + 2px;
+      font-size: 13px;
       outline: none;
+    }
 
-      &:hover {
+    & @{deep} dp-calendar-month {
+      .dp-calendar-weekday {
+        height: @basic-height - 5px;
+        width: @basic-height;
+        line-height: @basic-height - 5px;
         background: #E0E0E0;
+        border: none;
       }
-    }
 
-    .dp-selected {
-      background: #106CC8;
-      color: white;
+      .dp-calendar-wrapper {
+        border: none;
+      }
 
-      &:hover {
+      .dp-calendar-day {
+        box-sizing: border-box;
+        height: @basic-height;
+        width: @basic-height;
+        background: white;
+        border-radius: 50%;
+        border: none;
+        outline: none;
+
+        &:hover {
+          background: #E0E0E0;
+        }
+      }
+
+      .dp-selected {
         background: #106CC8;
-      }
-    }
+        color: white;
 
-    .dp-current-day {
-      border: 1px solid #106CC8;
+        &:hover {
+          background: #106CC8;
+        }
+      }
+
+      .dp-current-day {
+        border: 1px solid #106CC8;
+      }
     }
   }
 }

--- a/src/app/dp-calendar/dp-calendar.component.spec.ts
+++ b/src/app/dp-calendar/dp-calendar.component.spec.ts
@@ -1,8 +1,26 @@
-/* tslint:disable:no-unused-variable */
+import { DpCalendarMonthComponent } from './../dp-calendar-month/dp-calendar-month.component';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { TestBed, async } from '@angular/core/testing';
 import { DpCalendarComponent } from './dp-calendar.component';
 
-describe('Component: ObCalendar', () => {
+describe('DpCalendarComponent', () => {
+  let component: DpCalendarComponent;
+  let fixture: ComponentFixture<DpCalendarComponent>;
 
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ DpCalendarComponent, DpCalendarMonthComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DpCalendarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
 });

--- a/src/app/dp-date-picker.module.ts
+++ b/src/app/dp-date-picker.module.ts
@@ -2,19 +2,23 @@ import {NgModule} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {CommonModule} from '@angular/common';
 import {DpDayPickerComponent} from './dp-day-picker/dp-day-picker.component';
-import {DpCalendarComponent} from './dp-calendar/dp-calendar.component';
 export {DpDayPickerComponent} from './dp-day-picker/dp-day-picker.component'
+import {DpCalendarMonthComponent} from './dp-calendar-month/dp-calendar-month.component';
+export {DpCalendarMonthComponent} from './dp-calendar-month/dp-calendar-month.component';
+import {DpCalendarComponent} from './dp-calendar/dp-calendar.component';
+export {DpCalendarComponent} from './dp-calendar/dp-calendar.component';
 
 @NgModule({
   declarations: [
     DpDayPickerComponent,
+    DpCalendarMonthComponent,
     DpCalendarComponent
   ],
   imports: [
     CommonModule,
     FormsModule
   ],
-  exports: [DpDayPickerComponent, DpCalendarComponent]
+  exports: [DpDayPickerComponent, DpCalendarMonthComponent, DpCalendarComponent]
 })
 
 export class DpDatePickerModule {

--- a/src/app/dp-day-picker/dp-day-picker.api.ts
+++ b/src/app/dp-day-picker/dp-day-picker.api.ts
@@ -1,4 +1,4 @@
-export interface IObDayPickerApi {
+export interface IDpDayPickerApi {
   open: () => void;
   close: () => void;
 }

--- a/src/app/dp-day-picker/dp-day-picker.component.html
+++ b/src/app/dp-day-picker/dp-day-picker.component.html
@@ -7,26 +7,7 @@
          (focus)="inputFocused()"
          (keydown)="onKeydown($event)"
          [disabled]="disabled"/>
-  <div class="dp-calendars-container" *ngIf="areCalendarsShown">
-    <div class="dp-calendar-container"
-         *ngFor="let calendar of calendars; let start = first; let end = last">
-      <div class="dp-calendar-nav-container">
-        <button class="dp-calendar-nav-left"
-                *ngIf="start"
-                [disabled]="isLeftNavDisabled(calendar.month)"
-                (click)="moveCalendars(calendars[0].month, -1)"> <
-        </button>
-        <span class="dp-calendar-month">{{getMonthToDisplay(calendar.month)}}</span>
-        <button class="dp-calendar-nav-right"
-                *ngIf="end"
-                [disabled]="isRightNavDisabled(calendar.month)"
-                (click)="moveCalendars(calendars[0].month, 1)"> >
-        </button>
-      </div>
-      <dp-calendar [selected]="value"
-                   [config]="calendar"
-                   (on-change)="daySelected($event)">
-      </dp-calendar>
-    </div>
+  <div class="dp-popup" *ngIf="areCalendarsShown">
+    <dp-calendar class="dp-material" [(selected)]="value" [config]="pickerConfig"></dp-calendar>
   </div>
 </div>

--- a/src/app/dp-day-picker/dp-day-picker.component.less
+++ b/src/app/dp-day-picker/dp-day-picker.component.less
@@ -6,7 +6,7 @@
     display: inline-block;
   }
 
-  .dp-calendars-container {
+  .dp-popup {
     position: absolute;
     background: @white;
     box-shadow: 1px 1px 5px 0 rgba(0, 0, 0, 0.1);
@@ -14,40 +14,6 @@
     border-right: 1px solid rgba(0, 0, 0, 0.1);
     border-bottom: 1px solid rgba(0, 0, 0, 0.1);
     z-index: 9999;
-  }
-
-  .dp-calendar-container {
-    display: inline-block;
-  }
-
-  .dp-calendar-nav-container {
-    position: relative;
-    box-sizing: border-box;
-    height: 25px;
-    border: 1px solid @black;
-    border-bottom: none;
-  }
-
-  .dp-calendar-nav-left, .dp-calendar-nav-right {
-    position: absolute;
-    top: 50%;
-    transform: translateY(-50%);
-    cursor: pointer;
-  }
-
-  .dp-calendar-nav-left {
-    left: 0;
-  }
-
-  .dp-calendar-nav-right {
-    right: 0;
-  }
-
-  .dp-calendar-month {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
   }
 }
 
@@ -85,7 +51,7 @@
       outline: none;
     }
 
-    & @{deep} dp-calendar {
+    & @{deep} dp-calendar-month {
       .dp-calendar-weekday {
         height: @basic-height - 5px;
         width: @basic-height;

--- a/src/app/dp-day-picker/dp-day-picker.component.spec.ts
+++ b/src/app/dp-day-picker/dp-day-picker.component.spec.ts
@@ -1,10 +1,10 @@
 /* tslint:disable:no-unused-variable */
-
+import {CalendarService} from './../dp-calendar/config/calendar.service';
 import {DpDayPickerComponent} from './dp-day-picker.component';
 import {DayPickerService} from './service/day-picker.service';
 
-describe('Component: ObDayPicker', () => {
-  const component = new DpDayPickerComponent(new DayPickerService());
+describe('Component: DpDayPicker', () => {
+  const component = new DpDayPickerComponent(new DayPickerService(new CalendarService()));
 
   it('should create an instance', () => {
     expect(component).toBeTruthy();

--- a/src/app/dp-day-picker/service/day-picker-config.model.ts
+++ b/src/app/dp-day-picker/service/day-picker-config.model.ts
@@ -1,19 +1,8 @@
-import {Moment} from 'moment';
-import {WeekDays} from '../../common/types/week-days.type';
+import { ICalendarConfig } from './../../dp-calendar/config/calendar-config.model';
 
-export interface IDayPickerConfig {
-  firstDayOfWeek?: WeekDays;
-  calendarsAmount?: number;
-  format?: string;
-  min?: Moment | string;
-  max?: Moment | string;
-  allowMultiSelect?: boolean;
+export interface IDayPickerConfig extends ICalendarConfig {
   closeOnSelect?: boolean;
   closeOnSelectDelay?: number;
-  weekdayNames?: {[key: string]: string};
   disableKeypress?: boolean;
-  isDisabledCallback?: (day: Moment) => boolean;
-  monthFormat?: string;
-  monthFormatter?: (date: Moment) => string;
   userValueType?: 'string' | 'object';
 }

--- a/src/app/dp-day-picker/service/day-picker.service.spec.ts
+++ b/src/app/dp-day-picker/service/day-picker.service.spec.ts
@@ -1,6 +1,7 @@
 /* tslint:disable:no-unused-variable */
 
 import {TestBed, async, inject} from '@angular/core/testing';
+import {CalendarService} from '../../dp-calendar/config/calendar.service';
 import {DayPickerService} from './day-picker.service';
 import * as moment from 'moment';
 import {Moment} from 'moment';
@@ -8,76 +9,14 @@ import {Moment} from 'moment';
 describe('Service: DayPicker', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [DayPickerService]
+      providers: [DayPickerService, CalendarService]
     });
   });
-
-  it('should check generateCalendars method', inject([DayPickerService], (service: DayPickerService) => {
-    const calendars1 = service.generateCalendars({calendarsAmount: 1}, null);
-    expect(calendars1.length).toBe(1);
-    expect(calendars1[0].month.isSame(moment(), 'month')).toBe(true);
-
-    const calendars2 = service.generateCalendars({calendarsAmount: 2}, null);
-    expect(calendars2.length).toBe(2);
-    expect(calendars2[0].month.isSame(moment(), 'month')).toBe(true);
-    expect(calendars2[1].month.isSame(moment().add(1, 'month'), 'month')).toBe(true);
-
-    const calendars2_1 = service.generateCalendars({calendarsAmount: 2}, []);
-    expect(calendars2_1.length).toBe(2);
-    expect(calendars2_1[0].month.isSame(moment(), 'month')).toBe(true);
-    expect(calendars2_1[1].month.isSame(moment().add(1, 'month'), 'month')).toBe(true);
-
-    const calendars3 = service.generateCalendars({calendarsAmount: 2}, [moment('13-10-2015', 'DD-MM-YYYY')]);
-    expect(calendars3.length).toBe(2);
-    expect(calendars3[0].month.isSame(moment('13-10-2015', 'DD-MM-YYYY'), 'month')).toBe(true);
-    expect(calendars3[1].month.isSame(moment('13-11-2015', 'DD-MM-YYYY'), 'month')).toBe(true);
-
-    const calendars3_1 = service.generateCalendars(
-      {calendarsAmount: 2},
-      [moment('13-10-2015', 'DD-MM-YYYY'), moment('13-11-2015', 'DD-MM-YYYY')]
-    );
-    expect(calendars3_1.length).toBe(2);
-    expect(calendars3_1[0].month.isSame(moment('13-10-2015', 'DD-MM-YYYY'), 'month')).toBe(true);
-    expect(calendars3_1[1].month.isSame(moment('13-11-2015', 'DD-MM-YYYY'), 'month')).toBe(true);
-
-    const calendars4 = service.generateCalendars({calendarsAmount: 2}, [moment()], moment('13-10-2015', 'DD-MM-YYYY'));
-    expect(calendars4.length).toBe(2);
-    expect(calendars4[0].month.isSame(moment('13-10-2015', 'DD-MM-YYYY'), 'month')).toBe(true);
-    expect(calendars4[1].month.isSame(moment('13-11-2015', 'DD-MM-YYYY'), 'month')).toBe(true);
-  }));
 
   it('should check isDateValid method', inject([DayPickerService], (service: DayPickerService) => {
     expect(service.isDateValid('13-10-2015', 'DD-MM-YYYY')).toBe(true);
     expect(service.isDateValid('13-10-2015', 'DD-MM-YY')).toBe(false);
     expect(service.isDateValid('', 'DD-MM-YY')).toBe(true);
-  }));
-
-  it('should check moveCalendars method', inject([DayPickerService], (service: DayPickerService) => {
-    const calendars1 = service.moveCalendars({calendarsAmount: 1}, null, moment(), 1);
-    expect(calendars1.length).toBe(1);
-    expect(calendars1[0].month.isSame(moment().add(1, 'month'), 'month')).toBe(true);
-
-    const calendars2 = service.moveCalendars({calendarsAmount: 2}, null, moment(), 1);
-    expect(calendars2.length).toBe(2);
-    expect(calendars2[0].month.isSame(moment().add(1, 'month'), 'month')).toBe(true);
-    expect(calendars2[1].month.isSame(moment().add(2, 'month'), 'month')).toBe(true);
-
-    const calendars3 = service.moveCalendars({calendarsAmount: 2}, null, moment(), -1);
-    expect(calendars3.length).toBe(2);
-    expect(calendars3[0].month.isSame(moment().add(-1, 'month'), 'month')).toBe(true);
-    expect(calendars3[1].month.isSame(moment(), 'month')).toBe(true);
-  }));
-
-  it('should check isMinMonth method', inject([DayPickerService], (service: DayPickerService) => {
-    expect(service.isMinMonth(moment(), moment())).toBe(true);
-    expect(service.isMinMonth(moment().subtract(1, 'month'), moment())).toBe(false);
-    expect(service.isMinMonth(null, moment())).toBe(false);
-  }));
-
-  it('should check isMaxMonth method', inject([DayPickerService], (service: DayPickerService) => {
-    expect(service.isMaxMonth(moment(), moment())).toBe(true);
-    expect(service.isMaxMonth(moment().add(1, 'month'), moment())).toBe(false);
-    expect(service.isMinMonth(null, moment())).toBe(false);
   }));
 
   it('should check getConfig method for dates format aspect', inject([DayPickerService], (service: DayPickerService) => {

--- a/src/app/dp-day-picker/service/day-picker.service.ts
+++ b/src/app/dp-day-picker/service/day-picker.service.ts
@@ -1,43 +1,20 @@
+import {CalendarService} from './../../dp-calendar/config/calendar.service';
 import {Injectable} from '@angular/core';
 import {IDayPickerConfig} from './day-picker-config.model';
 import * as moment from 'moment';
 import {UtilsService} from '../../common/services/utils/utils.service';
-import {ICalendarConfig} from '../../dp-calendar/config/calendar-config.model';
 import {Moment} from 'moment';
 import {FormControl} from '@angular/forms';
 
 @Injectable()
 export class DayPickerService {
   private defaultConfig: IDayPickerConfig = {
-    firstDayOfWeek: 'su',
-    calendarsAmount: 1,
-    format: 'DD-MM-YYYY',
-    monthFormat: 'MMM, YYYY',
     closeOnSelect: true,
     closeOnSelectDelay: 100,
-    weekdayNames: {
-      su: 'sun',
-      mo: 'mon',
-      tu: 'tue',
-      we: 'wed',
-      th: 'thu',
-      fr: 'fri',
-      sa: 'sat'
-    },
     disableKeypress: false
   };
 
-  private formatValues(config: IDayPickerConfig): void {
-    const {format, min, max} = config;
-
-    if (min && typeof min === 'string') {
-      config.min = moment(min, format);
-    }
-
-    if (max && typeof max === 'string') {
-      config.max = moment(max, format);
-    }
-  }
+  constructor(private calendarContainerService: CalendarService) {}
 
   getConfig(config: IDayPickerConfig) {
     if (config && config.allowMultiSelect && config.closeOnSelect === undefined) {
@@ -45,20 +22,7 @@ export class DayPickerService {
       config.closeOnSelect = false;
     }
     const _config = Object.assign({}, this.defaultConfig, config);
-    this.formatValues(_config);
-    return _config;
-  }
-
-  generateCalendars(config: IDayPickerConfig, selected: Moment[], month?: Moment): ICalendarConfig[] {
-    const base = (month && month.clone()) || (selected && selected[0] && selected[0].clone()) || moment();
-    return UtilsService.createArray(config.calendarsAmount).map((n: number, i: number) => ({
-      month: base.clone().add(i, 'month'),
-      selected: selected,
-      firstDayOfWeek: config.firstDayOfWeek,
-      weekdayNames: config.weekdayNames,
-      min: <Moment>config.min,
-      max: <Moment>config.max
-    }));
+    return this.calendarContainerService.getConfig(_config);
   }
 
   isDateValid(date: string, format: string): boolean {
@@ -66,19 +30,6 @@ export class DayPickerService {
       return true;
     }
     return moment(date, format, true).isValid();
-  }
-
-  moveCalendars(config: IDayPickerConfig, selected: Moment[], base: Moment, months: number): ICalendarConfig[] {
-    const month = base.clone().add(months, 'month');
-    return this.generateCalendars(config, selected, month);
-  }
-
-  isMinMonth(min: Moment, month): boolean {
-    return min ? month.clone().subtract(1, 'month').isBefore(min, 'month') : false;
-  }
-
-  isMaxMonth(max: Moment, month): boolean {
-    return max ? month.clone().add(1, 'month').isAfter(max, 'month') : false;
   }
 
   createValidator({minDate, maxDate}, dateFormat: string) {

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -1,1 +1,5 @@
+export {IDayEvent} from './dp-calendar-month/config/day.model';
+export {ICalendarMonthConfig} from './dp-calendar-month/config/calendar-month-config.model';
+export {ICalendarConfig} from './dp-calendar/config/calendar-config.model';
+export {IDayPickerConfig} from './dp-day-picker/service/day-picker-config.model';
 export * from './dp-date-picker.module';


### PR DESCRIPTION
Changed the existing `dp-calendar` to `dp-calendar-month`
Added new `dp-calendar` that encapsulates the contents of the popup
There's also a Inline Demo page that shows off the new capabilities.

Todo:
- [x] Add documentation
- [x] Squash commits