### PR TITLE
chore(build): Use ngc to build lib

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,0 @@
-export * from './bin/app/index';

--- a/package.json
+++ b/package.json
@@ -2,11 +2,7 @@
   "name": "ng2-date-picker",
   "version": "0.6.2",
   "license": "MIT",
-  "main": "bin/app/index.js",
-  "files": [
-    "index.d.ts",
-    "bin"
-  ],
+  "main": "index.js",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
@@ -15,7 +11,9 @@
     "lint": "ng lint",
     "e2e": "ng e2e",
     "build-demo": "rm -rf dist/ && ng build --prod --bh /ng2-date-picker/",
-    "build-prod": "rm -rf bin && gulp build"
+    "build-prod": "ngc && cp package.json bin",
+    "pub:local": "cd bin && npm pack && cd ..",
+    "pub:lib": "npm publish bin"
   },
   "private": false,
   "keywords": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,10 +15,14 @@
     ]
   },
   "include": [
-    "src/app/dp-date-picker.module.ts"
+    "src/app/index.ts"
   ],
   "exclude": [
     "node_modules",
     "**/*.spec.ts"
-  ]
+  ],
+  "angularCompilerOptions": {
+    "skipTemplateCodegen": true,
+    "strictMetadataEmit": true
+  }
 }


### PR DESCRIPTION
This should solve #8 .

I haven't tested if the library still works correctly, but the error message doesn't happen any more.

No hard feelings if you don't merge the PR, but this should point you in the right direction.

Here's what I did:
1. Use `ngc` instead of `gulp` to build the library (so that you get `*.metadata.json` files)
2. Publish/pack the library using a copy of the package.json file in the bin folder

If you don't use a copy of the package.json file in the bin folder, you need to have the `outDir` for `tsconfig.json` be `./` which will mix up your source and compiled files.  As a consequence of copying the package.json file, all the paths in that file need to be relative to `./bin` not `./`.

Hope this helps.